### PR TITLE
Updating Tensorflow losses to version 2.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,7 @@ Drop-in replacement for tensorflow losses:
 Installation
 ------------
 
+The TensorFlow implementation requires the installation of TensorFlow-addons (<https://github.com/tensorflow/addons>)
 Simply copy relevant files to your project.
 
 

--- a/examples/linear_classification_tensorflow.py
+++ b/examples/linear_classification_tensorflow.py
@@ -5,9 +5,8 @@ import os, sys
 currentdir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(currentdir))
 
-import numpy as np
 import tensorflow as tf
-tf.enable_eager_execution()
+import numpy as np
 import matplotlib.pyplot as plt
 
 from fyl_tensorflow import logistic_loss
@@ -40,10 +39,10 @@ y = np.array([0] * 20 + [1] * 20, dtype=np.long)
 Y = None
 
 # Can also use a one-hot encoded matrix.
-#Y = np.zeros((X.shape[0], 2))
-#Y[np.arange(X.shape[0]), y] = 1
+Y = np.zeros((X.shape[0], 2))
+Y[np.arange(X.shape[0]), y] = 1
 
-tf.set_random_seed(0)
+tf.random.set_seed(0)
 
 model = tf.keras.models.Sequential([
     tf.keras.layers.Dense(units=2,
@@ -51,12 +50,12 @@ model = tf.keras.models.Sequential([
                           activation="linear"),
 ])
 
-optimizer = tf.train.GradientDescentOptimizer(learning_rate=learning_rate)
+optimizer = tf.optimizers.SGD(learning_rate=learning_rate)
 #optimizer = "SGD"
 
 model.compile(optimizer=optimizer,
               loss=loss,
-              lr=learning_rate)
+              metrics='accuracy')
 
 if Y is None:
     model.fit(X, y, epochs=num_epochs)

--- a/examples/linear_regression_tensorflow.py
+++ b/examples/linear_regression_tensorflow.py
@@ -9,12 +9,9 @@ import tensorflow as tf
 import numpy as np
 import matplotlib.pyplot as plt
 
-
 from fyl_tensorflow import squared_loss
 
-
-tf.set_random_seed(0)
-
+tf.random.set_seed(0)
 # Hyper-parameters
 num_epochs = 60
 learning_rate = 0.001
@@ -35,15 +32,15 @@ model = tf.keras.models.Sequential([
                           activation="linear"),
 ])
 
-optimizer = tf.train.GradientDescentOptimizer(learning_rate=learning_rate)
-#optimizer = "SGD"
+optimizer = tf.optimizers.SGD(learning_rate=learning_rate)
+# optimizer = "SGD"
 
 model.compile(optimizer=optimizer,
               loss=squared_loss,
-              lr=learning_rate)
+              metrics='mae')
 
 model.fit(X, y, epochs=num_epochs)
-#model.evaluate(X, y)
+# model.evaluate(X, y)
 
 # Plot the graph
 y_pred = model.predict(X)

--- a/fyl_tensorflow.py
+++ b/fyl_tensorflow.py
@@ -1,9 +1,10 @@
 # Author: Mathieu Blondel
+#         Okba Bekhelifi
 # License: Simplified BSD
 
 """
 Tensorflow implementation of
-
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
 Learning Classifiers with Fenchel-Young Losses:
     Generalized Entropies, Margins, and Algorithms.
 Mathieu Blondel, André F. T. Martins, Vlad Niculae.
@@ -11,6 +12,7 @@ https://arxiv.org/abs/1805.09717
 """
 
 import tensorflow as tf
+import tensorflow_addons as tfa
 
 
 def fy_loss(y_true, theta, predict, Omega, weights):
@@ -67,13 +69,14 @@ def squared_loss(y_true, theta, weights="average"):
 
 
 def Shannon_negentropy(p, axis):
-    tmp = p * tf.log(p)
-    tmp = tf.where(tf.is_nan(tmp), tf.zeros_like(tmp), tmp)
+    tmp = p * tf.math.log(p)
+    tmp = tf.where(tf.math.is_nan(tmp), tf.zeros_like(tmp), tmp)
     return tf.reduce_sum(tmp, axis)
 
 
 def logistic_predict(theta):
     return tf.nn.softmax(theta, axis=1)
+
 
 def logistic_Omega(p):
     return Shannon_negentropy(p, axis=1)
@@ -86,6 +89,7 @@ def logistic_loss(y_true, theta, weights="average"):
 def logistic_ova_predict(theta):
     return tf.nn.sigmoid(theta)
 
+
 def logistic_ova_Omega(p):
     return Shannon_negentropy(p, axis=1) + Shannon_negentropy(1-p, axis=1)
 
@@ -96,7 +100,7 @@ def logistic_ova_loss(y_true, theta, weights="average"):
 
 
 def sparsemax_predict(theta):
-    return tf.contrib.sparsemax.sparsemax(theta)
+    return tfa.activations.sparsemax(theta)
 
 
 def sparsemax_Omega(p):

--- a/tests/test_fyl_tensorflow.py
+++ b/tests/test_fyl_tensorflow.py
@@ -1,4 +1,5 @@
 # Author: Mathieu Blondel
+#         Okba Bekhelifi
 # License: Simplified BSD
 
 import os, sys
@@ -14,35 +15,35 @@ from fyl_tensorflow import sparsemax_loss
 
 
 def test_squared_loss():
-    with tf.Session() as sess:
+    with tf.compat.v1.Session() as sess:
         y_true = tf.constant([[1.7], [2.76], [2.09]])
         y_pred = tf.constant([[0.7], [3.76], [1.09]])
         loss = squared_loss(y_true, y_pred)
-        error = tf.test.compute_gradient_error(y_pred, y_pred.shape,
+        error = tf.compat.v1.test.compute_gradient_error(y_pred, y_pred.shape,
                                                loss, loss.shape)
         assert error < 1e-3
 
 
 def test_classification_losses():
     for loss_func in (logistic_loss, logistic_ova_loss, sparsemax_loss):
-        with tf.Session() as sess:
+        with tf.compat.v1.Session() as sess:
             y_true = tf.constant([0, 0, 1, 2])
-            theta = tf.random_normal((4, 3))
+            theta = tf.random.normal((4, 3))
             loss = loss_func(y_true, theta)
-            error = tf.test.compute_gradient_error(theta, theta.shape,
+            error = tf.compat.v1.test.compute_gradient_error(theta, theta.shape,
                                                    loss, loss.shape)
             assert error < 1e-3
 
 
 def test_classification_losses_multilabel():
     for loss_func in (logistic_loss, logistic_ova_loss, sparsemax_loss):
-        with tf.Session() as sess:
+        with tf.compat.v1.Session() as sess:
             y_true = tf.constant([[1, 0, 0],
                                    [1, 0, 0],
                                    [0, 1, 0],
                                    [0, 0, 1]])
-            theta = tf.random_normal((4, 3))
+            theta = tf.random.normal((4, 3))
             loss = loss_func(y_true, theta)
-            error = tf.test.compute_gradient_error(theta, theta.shape,
+            error = tf.compat.v1.test.compute_gradient_error(theta, theta.shape,
                                                    loss, loss.shape)
             assert error < 1e-3


### PR DESCRIPTION
This PR updates the Tensorflow implemetation of the losses to newer TF version 2.x. Tested in colab with TF 2.8.
Disclaimer: the test files are not updated yet.